### PR TITLE
Section heading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 *.tox
 __pycache__
 dist
+.cache
+.idea
+.python-version

--- a/pykss/section.py
+++ b/pykss/section.py
@@ -64,8 +64,15 @@ class Section(object):
                 in_modifiers = False
                 self._description_lines.append(line)
 
-        self._description = '\n'.join(self._description_lines).strip()
+        self._heading = self._description_lines[0] if len(self._description_lines) > 0 else ''
+        self._description = '\n'.join(self._description_lines[1:]).strip()
         self.add_example('\n'.join(self._example_lines).strip())
+
+    @property
+    def heading(self):
+        if not hasattr(self, '_heading'):
+            self.parse()
+        return self._heading
 
     @property
     def description(self):

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,8 @@ setup(
             'Django>=1.6',
             'flake8',
             'mock',
-            'pytest',
+            'pytest<=3.3',
+            'attrs==19.1.0',
         ],
     },
 )

--- a/tests/test_section.py
+++ b/tests/test_section.py
@@ -26,9 +26,12 @@ Styleguide 2.1.1.
         """
         self.section = Section(comment.strip(), 'example.css')
 
+    def test_parses_the_heading(self):
+        self.assertEqual(self.section.heading, '# Form Button')
+
     def test_parses_the_description(self):
         self.assertEqual(self.section.description,
-                         ('# Form Button\n\nYour standard form button.\n\n\n'
+                         ('Your standard form button.\n\n\n'
                           '    This is part of the description, '
                           'not a multiline modifier.'))
 


### PR DESCRIPTION
Denna PR inför stöd för _avsnittsrubriker_ geonm att låta den första raden i den parsade beskrivningen agera rubrik.